### PR TITLE
Fix dropdown close detection

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,7 +39,7 @@ function toggleDropdown(id) {
 
 // Cerrar dropdowns al hacer clic fuera
 window.onclick = function(event) {
-    if (!event.target.matches('.btn')) {
+    if (!event.target.closest('.dropdown')) {
         document.querySelectorAll('.dropdown-content').forEach(d => {
             d.classList.remove('show');
         });


### PR DESCRIPTION
## Summary
- update the global click handler to only close dropdown menus when the click occurs outside of any dropdown container

## Testing
- Manual verification of the currency menu: opened the dropdown, changed the currency selector, updated the exchange rate field, and confirmed it only closes after clicking outside

------
https://chatgpt.com/codex/tasks/task_e_68d6ced2db88832da38a4605c98dbc85