### PR TITLE
Add Supabase-backed cash flow CRUD

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,10 @@
                 <label for="loginUsuario">Usuario</label>
                 <input type="text" id="loginUsuario" placeholder="admin" autocomplete="username" required>
             </div>
+            <div class="login-group">
+                <label for="loginPassword">Contraseña</label>
+                <input type="password" id="loginPassword" placeholder="••••••" autocomplete="current-password" required>
+            </div>
             <p id="loginError" class="login-error" role="alert" aria-live="polite"></p>
             <button type="submit" class="btn btn-login">Ingresar</button>
         </form>
@@ -111,7 +115,7 @@
                 <h2 style="color: #2d3748; margin-bottom: 20px;">Productos y Servicios</h2>
                 
                 <div style="background: linear-gradient(135deg, #f0f4ff 0%, #e9ecef 100%); padding: 25px; border-radius: 15px; margin-bottom: 30px;">
-                    <h3 style="color: #4a5568; margin-bottom: 20px;">Agregar Producto/Servicio</h3>
+                    <h3 id="prod-form-title" style="color: #4a5568; margin-bottom: 20px;">Agregar Producto/Servicio</h3>
                     <div class="form-row">
                         <div>
                             <label>Nombre</label>
@@ -144,11 +148,16 @@
                             <input type="number" id="prod-unidades" placeholder="0">
                         </div>
                     </div>
-                    <button class="btn" onclick="agregarProducto()">
-                        ➕ Agregar Producto
-                    </button>
+                    <div style="display: flex; gap: 12px; flex-wrap: wrap;">
+                        <button id="prod-submit" class="btn" onclick="agregarProducto()">
+                            ➕ Agregar Producto
+                        </button>
+                        <button id="prod-cancelar" class="btn btn-secondary" type="button" onclick="cancelarEdicionProducto()" style="display: none;">
+                            ✖️ Cancelar edición
+                        </button>
+                    </div>
                 </div>
-                
+
                 <div id="lista-productos"></div>
             </div>
 
@@ -157,7 +166,7 @@
                 <h2 style="color: #2d3748; margin-bottom: 20px;">Costos Fijos</h2>
                 
                 <div style="background: linear-gradient(135deg, #fff5f5 0%, #ffe0e0 100%); padding: 25px; border-radius: 15px; margin-bottom: 30px;">
-                    <h3 style="color: #4a5568; margin-bottom: 20px;">Agregar Costo Fijo</h3>
+                    <h3 id="costo-form-title" style="color: #4a5568; margin-bottom: 20px;">Agregar Costo Fijo</h3>
                     <div class="form-row">
                         <div>
                             <label>Concepto</label>
@@ -182,11 +191,16 @@
                             </select>
                         </div>
                     </div>
-                    <button class="btn" style="background: linear-gradient(135deg, #f56565 0%, #ed8936 100%);" onclick="agregarCostoFijo()">
-                        ➕ Agregar Costo Fijo
-                    </button>
+                    <div style="display: flex; gap: 12px; flex-wrap: wrap;">
+                        <button id="costo-submit" class="btn btn-cost" type="button" onclick="agregarCostoFijo()">
+                            ➕ Agregar Costo Fijo
+                        </button>
+                        <button id="costo-cancelar" class="btn btn-secondary" type="button" onclick="cancelarEdicionCostoFijo()" style="display: none;">
+                            ✖️ Cancelar edición
+                        </button>
+                    </div>
                 </div>
-                
+
                 <div class="metric-card" style="max-width: 400px; margin: 0 auto 30px;">
                     <p class="metric-label">Total Costos Fijos Mensuales</p>
                     <p class="metric-value" id="total-costos-fijos">₡0</p>
@@ -200,7 +214,7 @@
                 <h2 style="color: #2d3748; margin-bottom: 20px;">Flujo de Caja</h2>
                 
                 <div style="background: linear-gradient(135deg, #f0fff4 0%, #dcfce7 100%); padding: 25px; border-radius: 15px; margin-bottom: 30px;">
-                    <h3 style="color: #4a5568; margin-bottom: 20px;">Registrar Transacción</h3>
+                    <h3 id="trans-form-title" style="color: #4a5568; margin-bottom: 20px;">Registrar Transacción</h3>
                     <div class="form-row">
                         <div>
                             <label>Fecha</label>
@@ -237,9 +251,14 @@
                             </select>
                         </div>
                     </div>
-                    <button class="btn btn-success" onclick="agregarTransaccion()">
-                        ➕ Agregar Transacción
-                    </button>
+                    <div style="display: flex; gap: 12px; flex-wrap: wrap;">
+                        <button id="trans-submit" class="btn btn-success" type="button" onclick="agregarTransaccion()">
+                            ➕ Agregar Transacción
+                        </button>
+                        <button id="trans-cancelar" class="btn btn-secondary" type="button" onclick="cancelarEdicionTransaccion()" style="display: none;">
+                            ✖️ Cancelar edición
+                        </button>
+                    </div>
                 </div>
                 
                 <div class="form-group">

--- a/styles.css
+++ b/styles.css
@@ -173,6 +173,10 @@ h1 {
     background: linear-gradient(135deg, #f56565 0%, #ed8936 100%);
 }
 
+.btn-cost {
+    background: linear-gradient(135deg, #f56565 0%, #ed8936 100%);
+}
+
 .btn-success {
     background: linear-gradient(135deg, #48bb78 0%, #38a169 100%);
 }
@@ -276,6 +280,98 @@ input:focus, select:focus {
     margin-bottom: 15px;
     transition: all 0.3s ease;
     border: 2px solid transparent;
+}
+
+.product-card-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 24px;
+    align-items: flex-start;
+    flex-wrap: wrap;
+}
+
+.product-card-main {
+    flex: 1 1 260px;
+    min-width: 240px;
+}
+
+.product-card-title {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 14px;
+}
+
+.product-name {
+    font-size: 18px;
+    font-weight: 600;
+    color: #2d3748;
+}
+
+.product-metrics-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 18px;
+}
+
+.info-value--positive {
+    color: #48bb78;
+}
+
+.info-value--highlight {
+    color: #667eea;
+}
+
+.info-value--negative {
+    color: #f56565;
+}
+
+.product-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 12px;
+    padding: 12px;
+    background: #edf2f7;
+    border-radius: 12px;
+    min-width: 200px;
+}
+
+.transaction-actions {
+    min-width: 220px;
+}
+
+.product-action-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: 600;
+    border-radius: 10px;
+    padding: 10px 16px;
+    border: none;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.product-action-icon {
+    font-size: 16px;
+    line-height: 1;
+}
+
+.product-card.editing,
+.cost-card.editing,
+.transaction-card.editing {
+    border-color: #fbbf24;
+    box-shadow: 0 10px 25px rgba(251, 191, 36, 0.3);
+}
+
+.product-card.confirming-delete,
+.cost-card.confirming-delete,
+.transaction-card.confirming-delete {
+    border-color: #f87171;
+    box-shadow: 0 10px 25px rgba(248, 113, 113, 0.25);
 }
 
 .product-card:hover, .cost-card:hover, .transaction-card:hover {
@@ -424,14 +520,92 @@ input:focus, select:focus {
     background: #fee2e2;
     color: #991b1b;
     border: none;
-    padding: 8px;
-    border-radius: 8px;
+    padding: 10px 16px;
+    border-radius: 10px;
     cursor: pointer;
     transition: all 0.3s ease;
 }
 
 .delete-btn:hover {
     background: #fecaca;
+}
+
+.edit-btn {
+    background: #dbeafe;
+    color: #1e3a8a;
+    border: none;
+    padding: 10px 16px;
+    border-radius: 10px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.edit-btn:hover {
+    background: #bfdbfe;
+}
+
+.delete-warning {
+    margin-top: 16px;
+    border-radius: 12px;
+    padding: 14px 16px;
+    background: #fef2f2;
+    border: 1px solid #fecaca;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.warning-content {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    color: #b91c1c;
+    font-weight: 600;
+}
+
+.warning-icon {
+    font-size: 20px;
+}
+
+.warning-text {
+    flex: 1;
+    font-size: 14px;
+}
+
+.warning-actions {
+    display: flex;
+    gap: 10px;
+    justify-content: flex-end;
+}
+
+.cancel-delete-btn,
+.confirm-delete-btn {
+    border: none;
+    border-radius: 8px;
+    padding: 8px 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.cancel-delete-btn {
+    background: #e0e7ff;
+    color: #312e81;
+}
+
+.cancel-delete-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 14px rgba(49, 46, 129, 0.2);
+}
+
+.confirm-delete-btn {
+    background: #ef4444;
+    color: #fff;
+}
+
+.confirm-delete-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 14px rgba(239, 68, 68, 0.3);
 }
 
 .info-row {

--- a/tests/login.spec.js
+++ b/tests/login.spec.js
@@ -16,6 +16,10 @@ const html = `<!DOCTYPE html>
                 <label for="loginUsuario">Usuario</label>
                 <input type="text" id="loginUsuario" autocomplete="username" required>
             </div>
+            <div class="login-group">
+                <label for="loginPassword">Contraseña</label>
+                <input type="password" id="loginPassword" autocomplete="current-password" required>
+            </div>
             <p id="loginError" class="login-error" role="alert"></p>
             <button type="submit">Ingresar</button>
         </form>
@@ -53,18 +57,294 @@ window.Chart = function() {
 
 function crearClienteSupabaseMock() {
     return {
-        from() {
+        from(tabla) {
+            if (tabla === 'usuarios') {
+                return {
+                    select() {
+                        return {
+                            ilike(_columna, valor) {
+                                return {
+                                    limit() {
+                                        const coincide = valor.trim().toLowerCase() === 'admin';
+                                        return Promise.resolve({
+                                            data: coincide ? [{ id: 1, username: 'admin', password: 'supersecreto' }] : [],
+                                            error: null
+                                        });
+                                    }
+                                };
+                            }
+                        };
+                    }
+                };
+            }
+
+            if (tabla === 'productos') {
+                return {
+                    select() {
+                        return {
+                            eq() {
+                                return {
+                                    order() {
+                                        return Promise.resolve({ data: [], error: null });
+                                    }
+                                };
+                            }
+                        };
+                    },
+                    insert() {
+                        return {
+                            select() {
+                                return {
+                                    single() {
+                                        return Promise.resolve({
+                                            data: {
+                                                id: 99,
+                                                nombre: 'Mock',
+                                                tipo: 'producto',
+                                                moneda: 'CRC',
+                                                costo_unitario: 0,
+                                                precio_venta: 0,
+                                                unidades_vendidas: 0
+                                            },
+                                            error: null
+                                        });
+                                    }
+                                };
+                            }
+                        };
+                    },
+                    update(payload = {}) {
+                        const contexto = { payload, id: null };
+                        const builder = {
+                            eq(columna, valor) {
+                                if (columna === 'id') {
+                                    contexto.id = valor;
+                                }
+                                return builder;
+                            },
+                            select() {
+                                return {
+                                    single() {
+                                        return Promise.resolve({
+                                            data: {
+                                                id: contexto.id ?? 99,
+                                                nombre: payload.nombre ?? 'Mock Editado',
+                                                tipo: payload.tipo ?? 'producto',
+                                                moneda: payload.moneda ?? 'CRC',
+                                                costo_unitario: payload.costo_unitario ?? 0,
+                                                precio_venta: payload.precio_venta ?? 0,
+                                                unidades_vendidas: payload.unidades_vendidas ?? 0
+                                            },
+                                            error: null
+                                        });
+                                    }
+                                };
+                            }
+                        };
+                        return builder;
+                    },
+                    delete() {
+                        const contexto = { filtros: {} };
+                        const resultado = Promise.resolve({ data: null, error: null, contexto });
+                        const builder = {
+                            eq(columna, valor) {
+                                contexto.filtros[columna] = valor;
+                                return builder;
+                            },
+                            then(onFulfilled, onRejected) {
+                                return resultado.then(onFulfilled, onRejected);
+                            },
+                            catch(onRejected) {
+                                return resultado.catch(onRejected);
+                            },
+                            finally(onFinally) {
+                                return resultado.finally(onFinally);
+                            }
+                        };
+                        return builder;
+                    }
+                };
+            }
+
+            if (tabla === 'costos_fijos') {
+                return {
+                    select() {
+                        return {
+                            eq() {
+                                return {
+                                    order() {
+                                        return Promise.resolve({ data: [], error: null });
+                                    }
+                                };
+                            }
+                        };
+                    },
+                    insert() {
+                        return {
+                            select() {
+                                return {
+                                    single() {
+                                        return Promise.resolve({
+                                            data: {
+                                                id: 101,
+                                                concepto: 'Renta',
+                                                moneda: 'CRC',
+                                                monto: 1000,
+                                                frecuencia: 'mensual'
+                                            },
+                                            error: null
+                                        });
+                                    }
+                                };
+                            }
+                        };
+                    },
+                    update(payload = {}) {
+                        const contexto = { payload, id: null };
+                        const builder = {
+                            eq(columna, valor) {
+                                if (columna === 'id') {
+                                    contexto.id = valor;
+                                }
+                                return builder;
+                            },
+                            select() {
+                                return {
+                                    single() {
+                                        return Promise.resolve({
+                                            data: {
+                                                id: contexto.id ?? 101,
+                                                concepto: payload.concepto ?? 'Renta',
+                                                moneda: payload.moneda ?? 'CRC',
+                                                monto: payload.monto ?? 1000,
+                                                frecuencia: payload.frecuencia ?? 'mensual'
+                                            },
+                                            error: null
+                                        });
+                                    }
+                                };
+                            }
+                        };
+                        return builder;
+                    },
+                    delete() {
+                        const contexto = { filtros: {} };
+                        const resultado = Promise.resolve({ data: null, error: null, contexto });
+                        const builder = {
+                            eq(columna, valor) {
+                                contexto.filtros[columna] = valor;
+                                return builder;
+                            },
+                            then(onFulfilled, onRejected) {
+                                return resultado.then(onFulfilled, onRejected);
+                            },
+                            catch(onRejected) {
+                                return resultado.catch(onRejected);
+                            },
+                            finally(onFinally) {
+                                return resultado.finally(onFinally);
+                            }
+                        };
+                        return builder;
+                    }
+                };
+            }
+
+            if (tabla === 'flujo_caja') {
+                return {
+                    select() {
+                        return {
+                            eq() {
+                                return {
+                                    order() {
+                                        return Promise.resolve({ data: [], error: null });
+                                    }
+                                };
+                            }
+                        };
+                    },
+                    insert() {
+                        return {
+                            select() {
+                                return {
+                                    single() {
+                                        return Promise.resolve({
+                                            data: {
+                                                id: 202,
+                                                fecha: '2024-01-15',
+                                                tipo: 'ingreso',
+                                                concepto: 'Venta',
+                                                moneda: 'CRC',
+                                                monto: 50000,
+                                                categoria: 'venta'
+                                            },
+                                            error: null
+                                        });
+                                    }
+                                };
+                            }
+                        };
+                    },
+                    update(payload = {}) {
+                        const contexto = { payload, id: null };
+                        const builder = {
+                            eq(columna, valor) {
+                                if (columna === 'id') {
+                                    contexto.id = valor;
+                                }
+                                return builder;
+                            },
+                            select() {
+                                return {
+                                    single() {
+                                        return Promise.resolve({
+                                            data: {
+                                                id: contexto.id ?? 202,
+                                                fecha: payload.fecha ?? '2024-01-15',
+                                                tipo: payload.tipo ?? 'ingreso',
+                                                concepto: payload.concepto ?? 'Venta',
+                                                moneda: payload.moneda ?? 'CRC',
+                                                monto: payload.monto ?? 50000,
+                                                categoria: payload.categoria ?? 'venta'
+                                            },
+                                            error: null
+                                        });
+                                    }
+                                };
+                            }
+                        };
+                        return builder;
+                    },
+                    delete() {
+                        const contexto = { filtros: {} };
+                        const resultado = Promise.resolve({ data: null, error: null, contexto });
+                        const builder = {
+                            eq(columna, valor) {
+                                contexto.filtros[columna] = valor;
+                                return builder;
+                            },
+                            then(onFulfilled, onRejected) {
+                                return resultado.then(onFulfilled, onRejected);
+                            },
+                            catch(onRejected) {
+                                return resultado.catch(onRejected);
+                            },
+                            finally(onFinally) {
+                                return resultado.finally(onFinally);
+                            }
+                        };
+                        return builder;
+                    }
+                };
+            }
+
             return {
                 select() {
                     return {
-                        ilike(_columna, valor) {
+                        eq() {
                             return {
-                                limit() {
-                                    const coincide = valor.trim().toLowerCase() === 'admin';
-                                    return Promise.resolve({
-                                        data: coincide ? [{ id: 1, username: 'admin' }] : [],
-                                        error: null
-                                    });
+                                order() {
+                                    return Promise.resolve({ data: [], error: null });
                                 }
                             };
                         }
@@ -99,6 +379,7 @@ async function main() {
     const mainContainer = window.document.querySelector('.container');
     const loginForm = window.document.getElementById('loginForm');
     const loginUsuario = window.document.getElementById('loginUsuario');
+    const loginPassword = window.document.getElementById('loginPassword');
     const loginError = window.document.getElementById('loginError');
     const submitButton = loginForm.querySelector('button[type="submit"]');
     const logoutButton = window.document.getElementById('logoutButton');
@@ -106,8 +387,18 @@ async function main() {
 
     assert(loginContainer && !loginContainer.classList.contains('hidden'), 'El formulario debe mostrarse tras iniciar.');
     assert(mainContainer && mainContainer.classList.contains('hidden'), 'El dashboard debe permanecer oculto inicialmente.');
+    assert(loginPassword, 'Debe existir un campo para la contraseña.');
+
+    loginUsuario.value = 'admin';
+    loginPassword.value = '';
+    loginForm.dispatchEvent(new window.Event('submit', { cancelable: true, bubbles: true }));
+    await new Promise(resolve => setTimeout(resolve, 5));
+
+    assert.strictEqual(window.sessionStorage.getItem('usuarioAutenticado'), null, 'No debe iniciar sesión si falta la contraseña.');
+    assert(!submitButton.disabled, 'El botón debe reactivarse tras validar credenciales incompletas.');
 
     loginUsuario.value = 'usuario';
+    loginPassword.value = 'supersecreto';
     loginForm.dispatchEvent(new window.Event('submit', { cancelable: true, bubbles: true }));
     await new Promise(resolve => setTimeout(resolve, 5));
 
@@ -117,6 +408,16 @@ async function main() {
     assert(mainContainer.classList.contains('hidden'), 'El dashboard debe seguir oculto tras fallo.');
 
     loginUsuario.value = 'admin';
+    loginPassword.value = 'incorrecta';
+    loginForm.dispatchEvent(new window.Event('submit', { cancelable: true, bubbles: true }));
+    await new Promise(resolve => setTimeout(resolve, 5));
+
+    assert.strictEqual(window.sessionStorage.getItem('usuarioAutenticado'), null, 'No debe guardarse sesión con contraseña inválida.');
+    assert(loginError.textContent.includes('Usuario no autorizado'), 'Debe mostrar error de contraseña inválida.');
+    assert.strictEqual(loginPassword.value, '', 'La contraseña debe limpiarse tras un fallo.');
+
+    loginUsuario.value = 'admin';
+    loginPassword.value = 'supersecreto';
     loginForm.dispatchEvent(new window.Event('submit', { cancelable: true, bubbles: true }));
     await new Promise(resolve => setTimeout(resolve, 5));
 
@@ -135,6 +436,7 @@ async function main() {
     assert(!loginContainer.classList.contains('hidden'), 'El formulario debe mostrarse nuevamente tras cerrar sesión.');
     assert(mainContainer.classList.contains('hidden'), 'El dashboard debe ocultarse tras cerrar sesión.');
     assert.strictEqual(loginUsuario.value, '', 'El campo de usuario debe reiniciarse tras cerrar sesión.');
+    assert.strictEqual(loginPassword.value, '', 'El campo de contraseña debe reiniciarse tras cerrar sesión.');
 }
 
 main().then(() => {


### PR DESCRIPTION
## Summary
- add Supabase synchronization and full CRUD handlers for cash flow transactions mirrored on the product workflow
- refresh the cash flow dashboard with edit/cancel controls, confirmation banners, and styled action buttons
- extend the Supabase mock to cover cash flow selects, inserts, updates, and deletes exercised by the tests

## Testing
- npm run test:login

------
https://chatgpt.com/codex/tasks/task_e_68d70b30879c832d8beb4acdf26328b9