### PR TITLE
Fix cash flow month selector to show latest available data

### DIFF
--- a/index.html
+++ b/index.html
@@ -263,7 +263,7 @@
                 
                 <div class="form-group">
                     <label>Seleccionar Mes</label>
-                    <input type="month" id="mes-seleccionado" onchange="actualizarFlujoCaja()" style="max-width: 200px;">
+                    <input type="month" id="mes-seleccionado" onchange="manejarCambioMes()" style="max-width: 200px;">
                 </div>
                 
                 <div class="grid">


### PR DESCRIPTION
## Summary
- add logic to auto-select the most recent month with transactions when syncing flujo de caja
- track manual month selections and reset the selector on logout or data cleanup

## Testing
- npm run test:login

------
https://chatgpt.com/codex/tasks/task_e_68d747e48aac832dbe72afce450815f8