### PR TITLE
Add manual refresh buttons and improve module lists

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,7 +112,12 @@
 
             <!-- Tab de Productos -->
             <div id="tab-productos" class="tab-content active">
-                <h2 style="color: #2d3748; margin-bottom: 20px;">Productos y Servicios</h2>
+                <div class="section-header">
+                    <h2>Productos y Servicios</h2>
+                    <button id="btn-refrescar-productos" class="btn btn-refresh" type="button" onclick="refrescarProductos()">
+                        🔄 Refrescar
+                    </button>
+                </div>
                 
                 <div style="background: linear-gradient(135deg, #f0f4ff 0%, #e9ecef 100%); padding: 25px; border-radius: 15px; margin-bottom: 30px;">
                     <h3 id="prod-form-title" style="color: #4a5568; margin-bottom: 20px;">Agregar Producto/Servicio</h3>
@@ -158,12 +163,17 @@
                     </div>
                 </div>
 
-                <div id="lista-productos"></div>
+                <div id="lista-productos" class="module-list"></div>
             </div>
 
             <!-- Tab de Costos Fijos -->
             <div id="tab-costos" class="tab-content">
-                <h2 style="color: #2d3748; margin-bottom: 20px;">Costos Fijos</h2>
+                <div class="section-header">
+                    <h2>Costos Fijos</h2>
+                    <button id="btn-refrescar-costos" class="btn btn-refresh" type="button" onclick="refrescarCostosFijos()">
+                        🔄 Refrescar
+                    </button>
+                </div>
                 
                 <div style="background: linear-gradient(135deg, #fff5f5 0%, #ffe0e0 100%); padding: 25px; border-radius: 15px; margin-bottom: 30px;">
                     <h3 id="costo-form-title" style="color: #4a5568; margin-bottom: 20px;">Agregar Costo Fijo</h3>
@@ -206,12 +216,17 @@
                     <p class="metric-value" id="total-costos-fijos">₡0</p>
                 </div>
                 
-                <div id="lista-costos"></div>
+                <div id="lista-costos" class="module-list"></div>
             </div>
 
             <!-- Tab de Flujo de Caja -->
             <div id="tab-flujo" class="tab-content">
-                <h2 style="color: #2d3748; margin-bottom: 20px;">Flujo de Caja</h2>
+                <div class="section-header">
+                    <h2>Flujo de Caja</h2>
+                    <button id="btn-refrescar-flujo" class="btn btn-refresh" type="button" onclick="refrescarFlujoCaja()">
+                        🔄 Refrescar
+                    </button>
+                </div>
                 
                 <div style="background: linear-gradient(135deg, #f0fff4 0%, #dcfce7 100%); padding: 25px; border-radius: 15px; margin-bottom: 30px;">
                     <h3 id="trans-form-title" style="color: #4a5568; margin-bottom: 20px;">Agregar Transacción</h3>
@@ -263,7 +278,7 @@
                 
                 <div class="form-group">
                     <label>Seleccionar Mes</label>
-                    <input type="month" id="mes-seleccionado" onchange="actualizarFlujoCaja()" style="max-width: 200px;">
+                    <input type="month" id="mes-seleccionado" onchange="manejarCambioMes()" style="max-width: 200px;">
                 </div>
                 
                 <div class="grid">
@@ -285,12 +300,17 @@
                     <canvas id="flujoChart"></canvas>
                 </div>
                 
-                <div id="lista-transacciones"></div>
+                <div id="lista-transacciones" class="module-list"></div>
             </div>
 
             <!-- Tab de Análisis -->
             <div id="tab-analisis" class="tab-content">
-                <h2 style="color: #2d3748; margin-bottom: 20px;">Análisis y Punto de Equilibrio</h2>
+                <div class="section-header">
+                    <h2>Análisis y Punto de Equilibrio</h2>
+                    <button id="btn-refrescar-analisis" class="btn btn-refresh" type="button" onclick="refrescarAnalisis()">
+                        🔄 Refrescar
+                    </button>
+                </div>
                 
                 <div class="grid">
                     <div class="metric-card">

--- a/styles.css
+++ b/styles.css
@@ -225,6 +225,72 @@ h1 {
     background: linear-gradient(90deg, #667eea 0%, #764ba2 100%);
 }
 
+.section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 20px;
+    flex-wrap: wrap;
+}
+
+.section-header h2 {
+    margin: 0;
+    color: #2d3748;
+    font-size: 26px;
+}
+
+.btn-refresh {
+    background: #ffffff;
+    color: #4a5568;
+    border: 2px solid #cbd5f5;
+    box-shadow: none;
+}
+
+.btn-refresh:hover {
+    background: #ebf4ff;
+    color: #2c5282;
+    box-shadow: 0 10px 20px rgba(102, 126, 234, 0.15);
+}
+
+.btn-refresh.is-loading {
+    color: #718096;
+}
+
+.btn[disabled] {
+    opacity: 0.6;
+    cursor: not-allowed;
+    transform: none;
+    box-shadow: none;
+}
+
+.module-list {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+    max-height: clamp(320px, 60vh, 560px);
+    overflow-y: auto;
+    padding-right: 8px;
+}
+
+.module-list > * {
+    margin-bottom: 0 !important;
+}
+
+.module-list::-webkit-scrollbar {
+    width: 8px;
+}
+
+.module-list::-webkit-scrollbar-thumb {
+    background: rgba(102, 126, 234, 0.35);
+    border-radius: 4px;
+}
+
+.module-list::-webkit-scrollbar-track {
+    background: rgba(237, 242, 247, 0.6);
+    border-radius: 4px;
+}
+
 .tab-content {
     display: none;
 }


### PR DESCRIPTION
## Summary
- add refresh buttons to each módulo for manual data syncing
- centralize refresh behavior in app.js to reload local storage and Supabase data
- style section headers and module lists for better visibility when many registros are present

## Testing
- npm run test:login

------
https://chatgpt.com/codex/tasks/task_e_68d747e48aac832dbe72afce450815f8